### PR TITLE
update rio terminal supported status

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -186,9 +186,9 @@ Could not find any sixel references in source code, mailing list archives, or re
 
 # Rio terminal
 
-{{< unsupported >}}
+{{< supported >}}
 
-Open issue: https://github.com/raphamorim/rio/issues/38
+[Natively supports sixel](https://raphamorim.io/rio/docs/features/sixel-protocol).
 
 ---
 


### PR DESCRIPTION
<img width="578" alt="demo-sixel-2" src="https://github.com/user-attachments/assets/80eae2ad-0a2f-4a7e-bf81-f30f7515c918">
