### PR TITLE
Windows Terminal confirmed supports sixels in the 1.22 Preview

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -351,9 +351,9 @@ Could not find any sixel references in source code.
 
 # Windows Terminal
 
-{{< unsupported >}}
+{{< supported >}}
 
-Open issue: https://github.com/microsoft/terminal/issues/448.
+Support from release 1.22, currently in preview: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-22-release/
 
 ---
 


### PR DESCRIPTION
I downloaded the 1.22 preview and verified that sixels work now.